### PR TITLE
Solves suspended vs buried issue

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,7 @@
     "Learned": "#080",
     "Unseen": "#a00",
     "Suspended": "#e7a100",
+    "Buried": "#e7a100",
     "Done on Date": "#ddd",
     "Days until done": "#ddd",
     "Total": "#ddd"

--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ class AddonConfig:
             "Learned": "#080",
             "Unseen": "#a00",
             "Suspended": "#e7a100",
+            "Buried": "#e7a100",
             "Done on Date": "#ddd",
             "Days until done": "#ddd",
             "Total": "#ddd",

--- a/table.py
+++ b/table.py
@@ -139,6 +139,13 @@ class Table:
             + """;
             }
 
+            td.buried {
+                font-weight: normal;
+                color: """
+            + self._config.stat_colors["Buried"]
+            + """;
+            }
+
             td.doneDate {
                 font-weight: bold;
                 color: """
@@ -251,6 +258,12 @@ class Table:
             <td class="row2 suspended">{deck_stats[suspended]:d}</td>
             <td class="row3 percent">{deck_percentages[suspended]:.0%}</td>
             <td class="row4 percent">ignored</td>
+        </tr>
+        <tr>
+            <td class="row1">{labels[buried]:s}</td>
+            <td class="row2 buried">{deck_stats[buried]:d}</td>
+            <td class="row3 percent">{deck_percentages[buried]:.0%}</td>
+            <td class="row4 percent">{deck_percentages_without_suspended[buried]:.0%}</td>
         </tr>
         <tr>
             <td colspan="4"><hr /></td>


### PR DESCRIPTION
The original script counts buried cards (queue in -2,-3) along with the suspended ones (queue = -1).

This meant that most often than not, the suspended cards count included cards that are just hidden until the next day (hidden because they are related to cards you've just seen).

I've separated the counts, and also added a row for the buried cards at the stats table.